### PR TITLE
Added scene scaling accorded to screen resolution

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -287,6 +287,7 @@ GameObject:
   - component: {fileID: 519420032}
   - component: {fileID: 519420031}
   - component: {fileID: 519420029}
+  - component: {fileID: 519420030}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -301,6 +302,17 @@ AudioListener:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_Enabled: 1
+--- !u!114 &519420030
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 519420028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8be657fc8d529b048b05dbfb5c057f31, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!20 &519420031
 Camera:
   m_ObjectHideFlags: 0
@@ -762,8 +774,8 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1431847482}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.01, y: -0.04, z: 0}
-  m_LocalScale: {x: 1.1929553, y: 0.9452618, z: 1}
+  m_LocalPosition: {x: -0.28, y: -0.07, z: 0}
+  m_LocalScale: {x: 1.5936722, y: 1.3697207, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 5

--- a/Assets/Scripts/ChangeCameraSize.cs
+++ b/Assets/Scripts/ChangeCameraSize.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ChangeCameraSize : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		float aspect = (float)Screen.width / (float)Screen.height;
+		if (aspect > 1.7f){
+            Camera.main.orthographicSize = 5f;}
+		else if (aspect == 1.6f){
+			Camera.main.orthographicSize = 5.5f;}
+		else if (aspect == 1.5f){
+			Camera.main.orthographicSize = 6f;}
+		else if (aspect < 1.4f && aspect > 1.3f){
+			Camera.main.orthographicSize = 6.7f;}
+		else if (aspect == 1.25f){
+			Camera.main.orthographicSize = 7f;
+		}
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Scripts/ChangeCameraSize.cs.meta
+++ b/Assets/Scripts/ChangeCameraSize.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8be657fc8d529b048b05dbfb5c057f31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/MemoryCard.cs
+++ b/Assets/Scripts/MemoryCard.cs
@@ -27,6 +27,7 @@ public class MemoryCard : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
+		 
 	}
 	
 	// Update is called once per frame

--- a/Assets/Scripts/SceneController.cs
+++ b/Assets/Scripts/SceneController.cs
@@ -9,6 +9,7 @@ public class SceneController : MonoBehaviour {
 	public const int gridCols = 4;
 	public const float offsetX = 3f;
 	public const float offsetY = 4f;
+
 	[SerializeField] private MemoryCard originalCard;
 	[SerializeField] private Sprite[] images;
 	[SerializeField] private TextMesh scoreLabel;


### PR DESCRIPTION
Fixed bug, when in some screen resolutions  objects in scene were shifting beyond the visible area. Fix is too simple and will be modified, but it works in resolutions as 5/4, 4/3, 3/2, 16/10 and 16/9.